### PR TITLE
Call to session_regenerate_id throws an error …

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -49,7 +49,6 @@ class Session
         ]);
         $params = session_get_cookie_params();
         setcookie(session_name(), '', 0, $params['path'], $params['domain'], $params['secure'], isset($params['httponly']));
-        session_regenerate_id(true);
     }
 
     /**


### PR DESCRIPTION
"session_regenerate_id(): Cannot regenerate session id - session is not active"